### PR TITLE
Environments parameters for BeforeAll and AfterAll

### DIFF
--- a/sample/codeception.yml
+++ b/sample/codeception.yml
@@ -19,12 +19,14 @@ extensions:
                 - command: echo "Before All with Description"
                   description: Description of command
                 - echo "Before All single line"
-                - command: echo 
+                - command: echo
                   params: "Before All Params"
                   description: Before All with Params
                 - command: "false"
                   description: BeforeAll. fail on run but ignore errors
                   ignoreErrors: true
+                - command: echo "Before All suite with phantom environment"
+                  environments: phantom
             AfterAll:
                 - command: echo "After All"
                 - command: uname
@@ -33,6 +35,8 @@ extensions:
                 - command: ver
                   description: Platform Windows
                   platforms: windows
+                - command: echo "After All suite with phantom,chrome environments"
+                  environments: ['phantom', 'chrome']
             BeforeSuite:
                 - command: echo "Before acceptance suite"
                   suites: ['acceptance']

--- a/src/EventsScripting.php
+++ b/src/EventsScripting.php
@@ -14,80 +14,80 @@ use Codeception\Exception\ExtensionException;
 
 class EventsScripting extends \Codeception\Platform\Extension
 {
-	// list events to listen to
-	public static $events = array(
-		//run before any tests
-		'module.init' => 'beforeModule',
+    // list events to listen to
+    public static $events = array(
+        //run before any tests
+        'module.init' => 'beforeModule',
 
-		//Before suite is executed
-		'suite.before' => 'beforeSuite',
+        //Before suite is executed
+        'suite.before' => 'beforeSuite',
 
-		//After suite was executed
-		'suite.after' => 'afterSuite',
-	);
+        //After suite was executed
+        'suite.after' => 'afterSuite',
+    );
 
-	public function __construct($config, $options)
-	{
-		parent::__construct($config, $options);
-	}
+    public function __construct($config, $options)
+    {
+        parent::__construct($config, $options);
+    }
 
-	public function __destruct()
-	{
-		$this->afterModule();
-	}
+    public function __destruct()
+    {
+        $this->afterModule();
+    }
 
-	/**
-	* run command
-	*/
-	private function runSimpleCommand($command, $description, $ignoreErrors)
-	{
-		$this->writeln("Starting : {$description}");
-		$lastLine = system($command, $retval);
-		if($lastLine === FALSE) {
-			$this->writeln("Command failed");
-			if(!$ignoreErrors) {
-				throw new ExtensionException($this, "Command {$command} failed");
-			}
-		}
-		if($retval !== 0) {
-			$this->writeln("Command result code : {$retval}");
-			if(!$ignoreErrors) {
-				throw new ExtensionException($this, "Command result code : {$retval}");
-			}
-		}
-	}
+    /**
+    * run command
+    */
+    private function runSimpleCommand($command, $description, $ignoreErrors)
+    {
+        $this->writeln("Starting : {$description}");
+        $lastLine = system($command, $retval);
+        if($lastLine === FALSE) {
+            $this->writeln("Command failed");
+            if(!$ignoreErrors) {
+                throw new ExtensionException($this, "Command {$command} failed");
+            }
+        }
+        if($retval !== 0) {
+            $this->writeln("Command result code : {$retval}");
+            if(!$ignoreErrors) {
+                throw new ExtensionException($this, "Command result code : {$retval}");
+            }
+        }
+    }
 
-	private function processCommand($command)
-	{
-		if(is_string($command)) {
-			$this->runSimpleCommand($command, $command, false);
-		} else if(is_array($command)) {
-			//extract params
-			if(!isset($command['command'])) {
-				throw new ExtensionException($this, "'command' value is expected, get : \r\n" . print_r($command, true));
-			}
-			$commandLine = $command['command'];
+    private function processCommand($command)
+    {
+        if(is_string($command)) {
+            $this->runSimpleCommand($command, $command, false);
+        } else if(is_array($command)) {
+            //extract params
+            if(!isset($command['command'])) {
+                throw new ExtensionException($this, "'command' value is expected, get : \r\n" . print_r($command, true));
+            }
+            $commandLine = $command['command'];
 
-			$ignoreErrors = false;
-			if(isset($command['ignoreErrors'])) {
-				$ignoreErrors = (bool)$command['ignoreErrors'];
-			}
+            $ignoreErrors = false;
+            if(isset($command['ignoreErrors'])) {
+                $ignoreErrors = (bool)$command['ignoreErrors'];
+            }
 
-			if(isset($command['params'])) {
-				$commandLine .= " " . $command['params'];
-			}
+            if(isset($command['params'])) {
+                $commandLine .= " " . $command['params'];
+            }
 
-			$description = $commandLine;
-			if(isset($command['description'])) {
-				$description = $command['description'];
-			}
+            $description = $commandLine;
+            if(isset($command['description'])) {
+                $description = $command['description'];
+            }
 
-			// check if current OS is supported
-			if(isset($command['platforms'])) {
-				if(!$this->isPlatformSupported($command['platforms'])) {
-					return;
-				}
-			}
+            // check if current OS is supported
+            if(isset($command['platforms'])) {
+                if(!$this->isPlatformSupported($command['platforms'])) {
+                    return;
+                }
+            }
 
             // check if environments are supported
             if(isset($command['environments'])) {
@@ -96,44 +96,44 @@ class EventsScripting extends \Codeception\Platform\Extension
                 }
             }
 
-			if(!empty($this->currentSuite) && isset($command['suites'])) {
-				$suites = $command['suites'];
-				if(is_string($suites)) {
-					$suites = [$suites];
-				}
-				//skip command, it's not for current suite
-				if(!in_array($this->currentSuite, $suites)
-					&& !in_array($this->currentSuiteBaseName, $suites)
-				) {
-					return;
-				}
-			}
+            if(!empty($this->currentSuite) && isset($command['suites'])) {
+                $suites = $command['suites'];
+                if(is_string($suites)) {
+                    $suites = [$suites];
+                }
+                //skip command, it's not for current suite
+                if(!in_array($this->currentSuite, $suites)
+                    && !in_array($this->currentSuiteBaseName, $suites)
+                ) {
+                    return;
+                }
+            }
 
-			$this->runSimpleCommand($commandLine, $description, $ignoreErrors);
-		} else {
-			$type = gettype($command);
-			throw new ExtensionException($this, "Command type '{$type}' is not supported, string or array is expected");
-		}
-	}
+            $this->runSimpleCommand($commandLine, $description, $ignoreErrors);
+        } else {
+            $type = gettype($command);
+            throw new ExtensionException($this, "Command type '{$type}' is not supported, string or array is expected");
+        }
+    }
 
-	private function isPlatformSupported($platforms)
-	{
-		$platformSupported = false; // default value
+    private function isPlatformSupported($platforms)
+    {
+        $platformSupported = false; // default value
 
-		if(is_string($platforms)) {
-			$platforms = [$platforms];
-		}
-		foreach($platforms as $platform) {
-			$platformSupported = preg_match("/{$platform}/i", PHP_OS);
-			if ($platformSupported) {
-				break;
-			}
-		}
-		return $platformSupported;
-	}
+        if(is_string($platforms)) {
+            $platforms = [$platforms];
+        }
+        foreach($platforms as $platform) {
+            $platformSupported = preg_match("/{$platform}/i", PHP_OS);
+            if ($platformSupported) {
+                break;
+            }
+        }
+        return $platformSupported;
+    }
 
     private function isEnvironmentSupported($environments)
-	{
+    {
         $environmentSupported = false;
 
         // if beforeAll or afterAll then use complete list of env
@@ -164,92 +164,92 @@ class EventsScripting extends \Codeception\Platform\Extension
 
         return $environmentSupported;
 
-	}
-
-	/**
-	* run each command
-	*/
-	private function runCommands(array $commands)
-	{
-		foreach($commands as $command) {
-			$this->processCommand($command);
-		}
-	}
-
-	/**
-	* exctract and run config group (like BeforeAll)
-	*/
-	private function runConfigGroup($groupName)
-	{
-		if(!isset($this->config[$groupName])) {
-			return;
-		}
-
-		$commands = &$this->config[$groupName];
-		if(!is_array($commands)) {
-			throw new ExtensionException($this, "EventScripting config error. {$groupName} should be array");
-		}
-
-		$this->runCommands($commands);
-	}
-
-	// methods that handle events
-
-	private $beforeAllWereRun = false;
-
-	/**
-	* Module Init, run before any tests
-	*/
-	public function beforeModule(\Codeception\Event\SuiteEvent $e)
-	{
-		if($this->beforeAllWereRun == false) {
-		    $this->runConfigGroup('BeforeAll');
-		    $this->beforeAllWereRun = true;
-		}
     }
 
-	//may contain environment names, like  'acceptance (phantom)' or 'acceptance (phantom, chrome)'
-	private $currentSuite = '';
+    /**
+    * run each command
+    */
+    private function runCommands(array $commands)
+    {
+        foreach($commands as $command) {
+            $this->processCommand($command);
+        }
+    }
 
-	//top level name - acceptance, functional
-	private $currentSuiteBaseName = '';
+    /**
+    * exctract and run config group (like BeforeAll)
+    */
+    private function runConfigGroup($groupName)
+    {
+        if(!isset($this->config[$groupName])) {
+            return;
+        }
 
-	//array with environments enabled
-	private $currentEnvironment = [];
+        $commands = &$this->config[$groupName];
+        if(!is_array($commands)) {
+            throw new ExtensionException($this, "EventScripting config error. {$groupName} should be array");
+        }
 
-	/**
-	* Module After, run after any tests
-	*/
-	public function afterModule()
-	{
-		$this->currentSuite = '';
-		$this->currentSuiteBaseName = '';
-		$this->currentEnvironment = [];
+        $this->runCommands($commands);
+    }
+
+    // methods that handle events
+
+    private $beforeAllWereRun = false;
+
+    /**
+    * Module Init, run before any tests
+    */
+    public function beforeModule(\Codeception\Event\SuiteEvent $e)
+    {
+        if($this->beforeAllWereRun == false) {
+            $this->runConfigGroup('BeforeAll');
+            $this->beforeAllWereRun = true;
+        }
+    }
+
+    //may contain environment names, like  'acceptance (phantom)' or 'acceptance (phantom, chrome)'
+    private $currentSuite = '';
+
+    //top level name - acceptance, functional
+    private $currentSuiteBaseName = '';
+
+    //array with environments enabled
+    private $currentEnvironment = [];
+
+    /**
+    * Module After, run after any tests
+    */
+    public function afterModule()
+    {
+        $this->currentSuite = '';
+        $this->currentSuiteBaseName = '';
+        $this->currentEnvironment = [];
         $this->beforeAllWereRun = false;
-		$this->runConfigGroup('AfterAll');
-	}
+        $this->runConfigGroup('AfterAll');
+    }
 
-	/**
-	* Before suite is executed
-	*/
-	public function beforeSuite(\Codeception\Event\SuiteEvent $e)
-	{
-		$this->currentSuite = $e->getSuite()->getName();
-		$this->currentSuiteBaseName = $e->getSuite()->getBaseName();
-		$settings = $e->getSettings();
-		if(isset($settings['current_environment'])) {
-			$this->currentEnvironment = explode(',', $settings['current_environment']);
-		} else {
-			$this->currentEnvironment = [];
-		}
-		$this->runConfigGroup('BeforeSuite');
-	}
+    /**
+    * Before suite is executed
+    */
+    public function beforeSuite(\Codeception\Event\SuiteEvent $e)
+    {
+        $this->currentSuite = $e->getSuite()->getName();
+        $this->currentSuiteBaseName = $e->getSuite()->getBaseName();
+        $settings = $e->getSettings();
+        if(isset($settings['current_environment'])) {
+            $this->currentEnvironment = explode(',', $settings['current_environment']);
+        } else {
+            $this->currentEnvironment = [];
+        }
+        $this->runConfigGroup('BeforeSuite');
+    }
 
-	/**
-	* After suite is executed
-	*/
-	public function afterSuite(\Codeception\Event\SuiteEvent $e)
-	{
-		$this->runConfigGroup('AfterSuite');
-	}
+    /**
+    * After suite is executed
+    */
+    public function afterSuite(\Codeception\Event\SuiteEvent $e)
+    {
+        $this->runConfigGroup('AfterSuite');
+    }
 }

--- a/test/tests/acceptance/AcceptanceTestCest.php
+++ b/test/tests/acceptance/AcceptanceTestCest.php
@@ -10,7 +10,7 @@ class AcceptanceTestCest
 	public function _after(AcceptanceTester $I)
 	{
 	}
-	
+
 	private $beforeAllSmall = <<<'EOF'
 Starting : echo "Before All"
 Before All
@@ -28,32 +28,42 @@ Before All Params
 Starting : BeforeAll. fail on run but ignore errors
 Command result code : 1
 EOF;
-	
-	
+
+    private $beforeAllEnv = <<<'EOF'
+Starting : echo "Before All suite with phantom environment"
+Before All suite with phantom environment
+EOF;
+
+
 	private $beforeAnySuite = <<<'EOF'
 Starting : echo "Before any suite"
 Before any suite
 EOF;
-	
+
 	private $afterAnySuite = <<<'EOF'
 Starting : echo "After any suite"
 After any suite
 EOF;
-	
+
 	private $afterAll = <<<'EOF'
 Starting : echo "After All"
 After All
 Starting : Platform
 EOF;
-	
+
 	private $beforeAcceptanceSuite = <<<'EOF'
 Starting : echo "Before acceptance suite"
 Before acceptance suite
 EOF;
-	
+
 	private $afterAcceptanceSuite = <<<'EOF'
 Starting : echo "After acceptance suite"
 After acceptance suite
+EOF;
+
+private $afterAllEnv = <<<'EOF'
+Starting : echo "After All suite with phantom,chrome environments"
+After All suite with phantom,chrome environments
 EOF;
 
     public function withoutSuitedCommandsTest(AcceptanceTester $I)
@@ -72,6 +82,8 @@ EOF;
 		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
 		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->dontSeeInShellOutput($this->beforeAllEnv);
+        $I->dontSeeInShellOutput($this->afterAllEnv);
 		chdir('../test/');
     }
 
@@ -91,6 +103,7 @@ EOF;
 		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
 		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->dontSeeInShellOutput($this->beforeAllEnv);
 		chdir('../test/');
     }
 
@@ -110,9 +123,11 @@ EOF;
 		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
 		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->dontSeeInShellOutput($this->beforeAllEnv);
+        $I->dontSeeInShellOutput($this->afterAllEnv);
 		chdir('../test/');
     }
-	
+
 	public function withSuitedEnvironmentNoCommandsTest(AcceptanceTester $I)
     {
 		chdir('../sample/');
@@ -129,14 +144,16 @@ EOF;
 		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
 		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->dontSeeInShellOutput($this->beforeAllEnv);
+        $I->dontSeeInShellOutput($this->afterAllEnv);
 		chdir('../test/');
     }
-	
+
 	private $twoEnvironmentsOut = <<<'EOF'
 Starting : echo "Before acceptance suite, phantom,chrome environments"
 Before acceptance suite, phantom,chrome environments
 EOF;
-	
+
 	public function withSuitedEnvironmentOneCommandsTest(AcceptanceTester $I)
     {
 		chdir('../sample/');
@@ -153,14 +170,16 @@ EOF;
 		$I->seeInShellOutput($this->twoEnvironmentsOut);
 		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->dontSeeInShellOutput($this->beforeAllEnv);
+        $I->seeInShellOutput($this->afterAllEnv);
 		chdir('../test/');
     }
-	
+
 	private $oneEnvironmentsOut = <<<'EOF'
 Starting : echo "Before acceptance suite, phantom environment"
 Before acceptance suite, phantom environment
 EOF;
-	
+
 	public function withSuitedEnvironmentTwoCommandsTest(AcceptanceTester $I)
 	{
 		chdir('../sample/');
@@ -177,6 +196,8 @@ EOF;
 		$I->seeInShellOutput($this->twoEnvironmentsOut);
 		$I->seeInShellOutput($this->oneEnvironmentsOut);
 		$I->seeInShellOutput(PHP_OS);
+        $I->seeInShellOutput($this->beforeAllEnv);
+        $I->seeInShellOutput($this->afterAllEnv);
 		chdir('../test/');
 	}
 

--- a/test/tests/acceptance/AcceptanceTestCest.php
+++ b/test/tests/acceptance/AcceptanceTestCest.php
@@ -3,20 +3,20 @@
 
 class AcceptanceTestCest
 {
-	public function _before(AcceptanceTester $I)
-	{
-	}
+    public function _before(AcceptanceTester $I)
+    {
+    }
 
-	public function _after(AcceptanceTester $I)
-	{
-	}
+    public function _after(AcceptanceTester $I)
+    {
+    }
 
-	private $beforeAllSmall = <<<'EOF'
+    private $beforeAllSmall = <<<'EOF'
 Starting : echo "Before All"
 Before All
 EOF;
 
-	private $beforeAll = <<<'EOF'
+    private $beforeAll = <<<'EOF'
 Starting : echo "Before All"
 Before All
 Starting : Description of command
@@ -35,28 +35,28 @@ Before All suite with phantom environment
 EOF;
 
 
-	private $beforeAnySuite = <<<'EOF'
+    private $beforeAnySuite = <<<'EOF'
 Starting : echo "Before any suite"
 Before any suite
 EOF;
 
-	private $afterAnySuite = <<<'EOF'
+    private $afterAnySuite = <<<'EOF'
 Starting : echo "After any suite"
 After any suite
 EOF;
 
-	private $afterAll = <<<'EOF'
+    private $afterAll = <<<'EOF'
 Starting : echo "After All"
 After All
 Starting : Platform
 EOF;
 
-	private $beforeAcceptanceSuite = <<<'EOF'
+    private $beforeAcceptanceSuite = <<<'EOF'
 Starting : echo "Before acceptance suite"
 Before acceptance suite
 EOF;
 
-	private $afterAcceptanceSuite = <<<'EOF'
+    private $afterAcceptanceSuite = <<<'EOF'
 Starting : echo "After acceptance suite"
 After acceptance suite
 EOF;
@@ -68,137 +68,137 @@ EOF;
 
     public function withoutSuitedCommandsTest(AcceptanceTester $I)
     {
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run functional --no-colors');
-		$I->seeInShellOutput("Functional Tests");
-		$I->dontSeeInShellOutput("Acceptance Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->dontSeeInShellOutput($this->beforeAcceptanceSuite);
-		$I->dontSeeInShellOutput($this->afterAcceptanceSuite);
-		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
-		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run functional --no-colors');
+        $I->seeInShellOutput("Functional Tests");
+        $I->dontSeeInShellOutput("Acceptance Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->dontSeeInShellOutput($this->beforeAcceptanceSuite);
+        $I->dontSeeInShellOutput($this->afterAcceptanceSuite);
+        $I->dontSeeInShellOutput($this->twoEnvironmentsOut);
+        $I->dontSeeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->dontSeeInShellOutput($this->beforeAllEnv);
         $I->dontSeeInShellOutput($this->afterAllEnv);
-		chdir('../test/');
+        chdir('../test/');
     }
 
     public function withSuitedCommandsTest(AcceptanceTester $I)
     {
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run acceptance --no-colors');
-		$I->dontSeeInShellOutput("Functional Tests");
-		$I->seeInShellOutput("Acceptance Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->seeInShellOutput($this->beforeAcceptanceSuite);
-		$I->seeInShellOutput($this->afterAcceptanceSuite);
-		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
-		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run acceptance --no-colors');
+        $I->dontSeeInShellOutput("Functional Tests");
+        $I->seeInShellOutput("Acceptance Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->seeInShellOutput($this->beforeAcceptanceSuite);
+        $I->seeInShellOutput($this->afterAcceptanceSuite);
+        $I->dontSeeInShellOutput($this->twoEnvironmentsOut);
+        $I->dontSeeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->dontSeeInShellOutput($this->beforeAllEnv);
-		chdir('../test/');
+        chdir('../test/');
     }
 
     public function fullCommandsTest(AcceptanceTester $I)
     {
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run --no-colors');
-		$I->seeInShellOutput("Functional Tests");
-		$I->seeInShellOutput("Acceptance Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->seeInShellOutput($this->beforeAcceptanceSuite);
-		$I->seeInShellOutput($this->afterAcceptanceSuite);
-		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
-		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run --no-colors');
+        $I->seeInShellOutput("Functional Tests");
+        $I->seeInShellOutput("Acceptance Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->seeInShellOutput($this->beforeAcceptanceSuite);
+        $I->seeInShellOutput($this->afterAcceptanceSuite);
+        $I->dontSeeInShellOutput($this->twoEnvironmentsOut);
+        $I->dontSeeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->dontSeeInShellOutput($this->beforeAllEnv);
         $I->dontSeeInShellOutput($this->afterAllEnv);
-		chdir('../test/');
+        chdir('../test/');
     }
 
-	public function withSuitedEnvironmentNoCommandsTest(AcceptanceTester $I)
+    public function withSuitedEnvironmentNoCommandsTest(AcceptanceTester $I)
     {
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run acceptance --env firefox --no-colors');
-		$I->dontSeeInShellOutput("Functional Tests");
-		$I->seeInShellOutput("Acceptance (firefox) Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->seeInShellOutput($this->beforeAcceptanceSuite);
-		$I->seeInShellOutput($this->afterAcceptanceSuite);
-		$I->dontSeeInShellOutput($this->twoEnvironmentsOut);
-		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run acceptance --env firefox --no-colors');
+        $I->dontSeeInShellOutput("Functional Tests");
+        $I->seeInShellOutput("Acceptance (firefox) Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->seeInShellOutput($this->beforeAcceptanceSuite);
+        $I->seeInShellOutput($this->afterAcceptanceSuite);
+        $I->dontSeeInShellOutput($this->twoEnvironmentsOut);
+        $I->dontSeeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->dontSeeInShellOutput($this->beforeAllEnv);
         $I->dontSeeInShellOutput($this->afterAllEnv);
-		chdir('../test/');
+        chdir('../test/');
     }
 
-	private $twoEnvironmentsOut = <<<'EOF'
+    private $twoEnvironmentsOut = <<<'EOF'
 Starting : echo "Before acceptance suite, phantom,chrome environments"
 Before acceptance suite, phantom,chrome environments
 EOF;
 
-	public function withSuitedEnvironmentOneCommandsTest(AcceptanceTester $I)
+    public function withSuitedEnvironmentOneCommandsTest(AcceptanceTester $I)
     {
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run acceptance --env chrome --no-colors');
-		$I->dontSeeInShellOutput("Functional Tests");
-		$I->seeInShellOutput("Acceptance (chrome) Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->seeInShellOutput($this->beforeAcceptanceSuite);
-		$I->seeInShellOutput($this->afterAcceptanceSuite);
-		$I->seeInShellOutput($this->twoEnvironmentsOut);
-		$I->dontSeeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run acceptance --env chrome --no-colors');
+        $I->dontSeeInShellOutput("Functional Tests");
+        $I->seeInShellOutput("Acceptance (chrome) Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->seeInShellOutput($this->beforeAcceptanceSuite);
+        $I->seeInShellOutput($this->afterAcceptanceSuite);
+        $I->seeInShellOutput($this->twoEnvironmentsOut);
+        $I->dontSeeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->dontSeeInShellOutput($this->beforeAllEnv);
         $I->seeInShellOutput($this->afterAllEnv);
-		chdir('../test/');
+        chdir('../test/');
     }
 
-	private $oneEnvironmentsOut = <<<'EOF'
+    private $oneEnvironmentsOut = <<<'EOF'
 Starting : echo "Before acceptance suite, phantom environment"
 Before acceptance suite, phantom environment
 EOF;
 
-	public function withSuitedEnvironmentTwoCommandsTest(AcceptanceTester $I)
-	{
-		chdir('../sample/');
-		$I->runShellCommand('./vendor/bin/codecept run acceptance --env phantom,firefox --no-colors');
-		$I->dontSeeInShellOutput("Functional Tests");
-		$I->seeInShellOutput("Acceptance (phantom, firefox) Tests");
-		$I->seeInShellOutput($this->beforeAllSmall);
-		$I->seeInShellOutput($this->beforeAll);
-		$I->seeInShellOutput($this->beforeAnySuite);
-		$I->seeInShellOutput($this->afterAnySuite);
-		$I->seeInShellOutput($this->afterAll);
-		$I->seeInShellOutput($this->beforeAcceptanceSuite);
-		$I->seeInShellOutput($this->afterAcceptanceSuite);
-		$I->seeInShellOutput($this->twoEnvironmentsOut);
-		$I->seeInShellOutput($this->oneEnvironmentsOut);
-		$I->seeInShellOutput(PHP_OS);
+    public function withSuitedEnvironmentTwoCommandsTest(AcceptanceTester $I)
+    {
+        chdir('../sample/');
+        $I->runShellCommand('./vendor/bin/codecept run acceptance --env phantom,firefox --no-colors');
+        $I->dontSeeInShellOutput("Functional Tests");
+        $I->seeInShellOutput("Acceptance (phantom, firefox) Tests");
+        $I->seeInShellOutput($this->beforeAllSmall);
+        $I->seeInShellOutput($this->beforeAll);
+        $I->seeInShellOutput($this->beforeAnySuite);
+        $I->seeInShellOutput($this->afterAnySuite);
+        $I->seeInShellOutput($this->afterAll);
+        $I->seeInShellOutput($this->beforeAcceptanceSuite);
+        $I->seeInShellOutput($this->afterAcceptanceSuite);
+        $I->seeInShellOutput($this->twoEnvironmentsOut);
+        $I->seeInShellOutput($this->oneEnvironmentsOut);
+        $I->seeInShellOutput(PHP_OS);
         $I->seeInShellOutput($this->beforeAllEnv);
         $I->seeInShellOutput($this->afterAllEnv);
-		chdir('../test/');
-	}
+        chdir('../test/');
+    }
 
 }


### PR DESCRIPTION
Implementation of the issue #4 

``` yaml
extensions:
    enabled:
        - Codeception\Extension\EventsScripting
    config:
        Codeception\Extension\EventsScripting:
            BeforeAll:
                - command: echo "Before All suite with phantom environment"
                  environments: phantom
            AfterAll:
                - command: echo "After All suite with phantom,chrome environments"
                  environments: ['phantom', 'chrome']
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oprudkyi/codeception-events-scripting/5)

<!-- Reviewable:end -->
