### PR TITLE
fix: support codeception v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "codeception/codeception": "^2.2||~3.1.3||~4.1.22||^5.0"
+        "codeception/codeception": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventsScripting.php
+++ b/src/EventsScripting.php
@@ -12,7 +12,7 @@ namespace Codeception\Extension;
 
 use Codeception\Exception\ExtensionException;
 
-class EventsScripting extends \Codeception\Platform\Extension
+class EventsScripting extends \Codeception\Extension
 {
 	// list events to listen to
 	public static $events = array(


### PR DESCRIPTION
sorry, my bad, codeception changed the namespace \Codeception\Platform\Extension to \Codeception\Extension